### PR TITLE
Small changes in the slides

### DIFF
--- a/_extensions/beatrizmilz/rladies/rladies.scss
+++ b/_extensions/beatrizmilz/rladies/rladies.scss
@@ -1,12 +1,12 @@
 /*-- scss:defaults --*/
 // importing fonts
-@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Lato&family=Yanone+Kaffeesatz&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Lato&family=Roboto&display=swap');
 
 // fonts
 $font-family-sans-serif: 'Lato', Tahoma, sans-serif !default;
 
 // headings
-$presentation-heading-font: 'Yanone Kaffeesatz',  Tahoma, sans-serif  !default;
+$presentation-heading-font: 'Roboto',  Tahoma, sans-serif  !default;
 $presentation-heading-color: #562457 !default;
 $h1-font-size: 1.6em !default;
 $h2-font-size: 1.3em !default;

--- a/index.qmd
+++ b/index.qmd
@@ -2,7 +2,9 @@
 title: "Welcome to R-Ladies St. Louis"
 subtitle: "Wrangling Data in the Tidyverse"
 date: "October 4, 2022"
-format: rladies-revealjs
+format: 
+  rladies-revealjs:
+    footer: "Code available on [GitHub](https://github.com/rladiesstl/meetup-oct4-2022)."
 self-contained: true
 ---
 

--- a/index.qmd
+++ b/index.qmd
@@ -27,7 +27,7 @@ Speaker notes go here.
 -   Started in San Francisco in 2012 and now has **206 chapters and more than 93,000** members globally (check out rladies.org for a Shiny dashboard)
 
 ```{r}
-#| echo: FALSE
+#| echo: false
 #| fig.align: center
 #| fig-height: 2
 


### PR DESCRIPTION
Hi! I made some small changes:

1. Changing the font
To change the style, you can change the file `_extensions/beatrizmilz/rladies/rladies.scss`.

The variable `$presentation-heading-font` stores the font used in all headings (`#`,  `##` , `###` ...), so i changed there to roboto.
We also have to import the font.

With other fonts, you can find the code for that in Google fonts:
<img width="1511" alt="Captura de Tela 2022-09-01 às 10 48 13" src="https://user-images.githubusercontent.com/42153618/187930432-9444c7bf-b99a-40d4-9979-980a40755bb5.png">


2. I changed the YAML so it's easier for you to change and try other revealjs options. You can find all the options [here](https://quarto.org/docs/reference/formats/presentations/revealjs.html). The change I made also makes it easier for you to change the slide's footer and add links to the meetup pages!

3. Changed something that quarto was complaining during rendering: the option was FALSE but in that place we use lower case.


- The other thing that you asked (the slide's text to start at the beginning of the page) I don't remember how I centered it... but when I find out, I'll tell you!


I hope this helps!